### PR TITLE
Fix service_method radio not selected on service page

### DIFF
--- a/docassemble/MAMotiontoVacateMaritalHome/data/questions/Motion to Vacate Marital Home.yml
+++ b/docassemble/MAMotiontoVacateMaritalHome/data/questions/Motion to Vacate Marital Home.yml
@@ -224,7 +224,7 @@ fields:
       - By email: electronic mail
       - By mail (with postage paid by me): first class mail, postage prepaid
       - other: other
-  - Other method: service_method
+  - Other method: service_method_other
     show if:
       variable: service_method
       is: other

--- a/docassemble/MAMotiontoVacateMaritalHome/data/sources/is_a_user.feature
+++ b/docassemble/MAMotiontoVacateMaritalHome/data/sources/is_a_user.feature
@@ -132,7 +132,7 @@ Scenario: I can obtain a motion to vacate against another party
     | date | 02/15/2024 |  |
     | ready_to_serve | True |  |
     | service_date | 02/15/2024 |  |
-    | service_method | electronic mail | service_date |  |
+    | service_method | electronic mail | service_date |
     | plaintiff[0] | users[0] |  |
     | plaintiff[0].name | users[0].name |  |
     | plaintiff[0].name.first | Sydney |  |

--- a/docassemble/MAMotiontoVacateMaritalHome/data/sources/is_a_user.feature
+++ b/docassemble/MAMotiontoVacateMaritalHome/data/sources/is_a_user.feature
@@ -132,7 +132,7 @@ Scenario: I can obtain a motion to vacate against another party
     | date | 02/15/2024 |  |
     | ready_to_serve | True |  |
     | service_date | 02/15/2024 |  |
-    | service_method | electronic mail |  |
+    | service_method | electronic mail | service_date |  |
     | plaintiff[0] | users[0] |  |
     | plaintiff[0].name | users[0].name |  |
     | plaintiff[0].name.first | Sydney |  |

--- a/docassemble/MAMotiontoVacateMaritalHome/data/sources/is_a_user.feature
+++ b/docassemble/MAMotiontoVacateMaritalHome/data/sources/is_a_user.feature
@@ -132,7 +132,7 @@ Scenario: I can obtain a motion to vacate against another party
     | date | 02/15/2024 |  |
     | ready_to_serve | True |  |
     | service_date | 02/15/2024 |  |
-    | service_method | electronic mail | service_date |
+    | service_method | electronic mail |  |
     | plaintiff[0] | users[0] |  |
     | plaintiff[0].name | users[0].name |  |
     | plaintiff[0].name.first | Sydney |  |
@@ -195,5 +195,5 @@ Scenario: I can obtain a motion to vacate against another party
     | al_form_requires_digital_signature | True |  |
     | signature_choice | this_device |  |
     | saw_signature_choice | True |  |
-    | signature | users[0].signature |  |
+    | users[0].signature |  | users[0].signature |
     | basic_questions_signature_flow | True |  |


### PR DESCRIPTION
The ALKiln test was failing on the service page because the radio button for `service_method` wasn't getting selected even though electronic mail is the correct value. The interview YAML had `service_method` defined twice - as a radio button and as a conditional "Other method" text field. ALKiln was matching both and setting the variable twice, which cleared the radio before submitting. The `service_date` trigger idea didn't work, as that wasn't the real issue

Fix - Renamed the "Other method" field variable to `service_method_other` in the interview YAML and fixed the signature row in the feature file.